### PR TITLE
better bootstrap: removing fail argument from bootstrap methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ If you wish you can run this command under a virtual environment.
    the creation of multiple variations of parameters, and the execution of
    tests with those parameter variations.
 
+ * Clear separation between tests and bootstrap stages: If something fails
+   during the setUp() metod execution, your test will be not marked as FAIL,
+   instead it will be flagged as ERROR. You can also use some decorators
+   (@cancel_on, @skipUnless, ...) around your test to avoid false positves.
+
 ## Running
 
 After installing the requirements, you can run the tests with the following

--- a/lavocado/helpers/domains.py
+++ b/lavocado/helpers/domains.py
@@ -34,7 +34,6 @@ class Domain:
         xml_content = read_file(xml_path)
         return conn.createXML(xml_content)
 
-    # TODO: Catch TestSetupException on @fail_on
     @classmethod
     def from_xml_template(cls, conn, suffix, arguments=None):
         template_path = defaults.TEMPLATE_PATH


### PR DESCRIPTION
We don't need the fail argument since those steps are better placed during the
setUp(), that will mark the test as ERROR by default.

Signed-off-by: Beraldo Leal <bleal@redhat.com>