### PR TITLE
Remove the __init__.py link to test.py

### DIFF
--- a/lavocado/__init__.py
+++ b/lavocado/__init__.py
@@ -1,1 +1,4 @@
-test.py
+__all__ = ['LibvirtTest']
+
+
+from lavocado.test import LibvirtTest


### PR DESCRIPTION
Because of an Avocado safeloader issue, an imported symbol with test
a class would not be followed, but only class definitions would.

This has now changed in Avocado as of d0f6f9f6fd, and tests should
be properly found.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Note: it may be wise to wait until Avocado 90.0 is released before including this change.